### PR TITLE
Remove additional empty line when output option is not specified

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let text = reg.render_template(&template, &data)?;
     match opt.output {
         Some(path) => fs::write(path, text)?,
-        None => println!("{}", text),
+        None => print!("{}", text),
     };
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct Opt {
     register_glob: Option<String>,
 
     #[structopt(short, long)]
-    /// Make error output verobse
+    /// Make error output verbose.
     verbose: bool,
 }
 
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     match opt.register_glob {
         Some(pattern) => {
             if opt.verbose {
-                eprintln!("Registring templates matching to {:?}", pattern);
+                eprintln!("Registering templates matching to {:?}", pattern);
             }
             register_templates_from_pattern(&mut reg, pattern)?;
         }


### PR DESCRIPTION
👋 Hi. I'm trying out Handlebars and came across this repository.

I found results are inconsistent depending on whether the `--output` option is specified or not. If the option is not specified, the output has one more empty line in the end because of `println!`.

```bash
# This works as expected.
hbs-cli <properties file> <template file> -o <output file>

# It produces an additional empty line in the end, which is inconsistent with the above.
hbs-cli <properties file> <template file> > <output file>
```

I just made a small change. Thanks.